### PR TITLE
fix: resolve space list query

### DIFF
--- a/src/lib/dinky-api.ts
+++ b/src/lib/dinky-api.ts
@@ -61,7 +61,7 @@ export async function listDocsPage(userId: string, page = 1, perPage = 12): Prom
   const to = from + perPage - 1
   const { data, count, error } = await supabase
     .from('documents')
-    .select('id, data, updated_at, created_at', { count: 'exact' })
+    .select('id, data', { count: 'exact' })
     .eq('user_id', userId)
     .order('updated_at', { ascending: false })
     .order('created_at', { ascending: false })


### PR DESCRIPTION
## Summary
- ensure spaces query only selects needed fields while still sorting by recency

## Testing
- `yarn lint`
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_b_68ba9ee277e8832fb0647cc03c56e1d3